### PR TITLE
Fix /automate:replicate example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Fortunately, this automation allows you to automatically replicate transactions 
 budget to another by adding a note to your account with the following content:
 
 ```
-automate:replicate to_budget=Household to_account=Alice from_category=Groceries to_category=Food cleared=yes to_flag=blue
+/automate:replicate to_budget=Household to_account=Alice from_category=Groceries to_category=Food cleared=yes to_flag=blue
 ```
 
 ### Automated Approvals


### PR DESCRIPTION
Add a missing backslash in the /automate:replicate example in the README.

See https://github.com/SierraSoftworks/ynab-automation/issues/131 :)